### PR TITLE
add peek operation

### DIFF
--- a/lib/relativity.js
+++ b/lib/relativity.js
@@ -19,6 +19,10 @@ Stamp.prototype = {
     var halves = this._id.split();
     return [new Stamp(halves[0], this._event), new Stamp(halves[1], this._event)];
   },
+  
+  peek: function() {
+    return new Stamp(new ID(0), this._event);
+  },
 
   join: function(other) {
     return new Stamp(this._id.sum(other._id), this._event.join(other._event));


### PR DESCRIPTION
According to the docs:

> Peek is a special case of fork that only copies the event component and creates a new stamp with a null id. It can be used to make messages that transport causal information.
